### PR TITLE
feat: remove teardown on terraform apply failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ This action can be used by including it as a step in a workflow.
 
 We can also use a binary built during the workflow by passing the path to the `node-path` input.
 
+You can ensure your testnet is always cleaned up in a workflow run by adding a job like this:
+```
+kill-if-fail:
+  name: kill testnet on fail
+  runs-on: ubuntu-latest
+  if: |
+    always() &&
+    (needs.launch-testnet.result=='failure' ||
+     needs.client.result=='failure' ||
+     needs.api.result=='failure' ||
+     needs.cli.result=='failure')
+  needs: [launch-testnet, client, api, cli]
+  steps:
+    - name: Kill testnet
+      uses: maidsafe/sn_testnet_action@master
+      with:
+        do-token: ${{ secrets.DO_TOKEN }}
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-access-key-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        action: 'destroy'
+    - name: Upload event file
+      uses: actions/upload-artifact@v2
+      with:
+        name: event-file
+        path: ${{ github.event_path }}
+```
+
+Obviously, you need to substitute the job names here with your own.
+
 # Inputs
 
 |Input|Description|Required|Default|

--- a/action.yml
+++ b/action.yml
@@ -70,8 +70,7 @@ runs:
           NODE_PATH=$WORKING_DIR/sn_node
         fi
         $WORKING_DIR/sn_testnet_tool/up.sh \
-          $WORKING_DIR/id_rsa "$NODE_COUNT" "$NODE_PATH" "$NODE_VERSION" "-auto-approve" \
-          || $WORKING_DIR/sn_testnet_tool/down.sh $WORKING_DIR/id_rsa "-auto-approve"
+          $WORKING_DIR/id_rsa "$NODE_COUNT" "$NODE_PATH" "$NODE_VERSION" "-auto-approve"
     - uses: actions/upload-artifact@v2
       with:
         name: node_connection_info.config


### PR DESCRIPTION
The call to `up.sh` was being combined with `|| down.sh` for the purposes of tearing down the
testnet if a failure occurs on the `terraform apply`. The problem with this is it masks a failure,
because it makes the script return a positive exit code. This has the effect that if you're using
this action and your testnet doesn't spin up correctly, the job you use it in will pass. You really
want to know that things failed at the `terraform apply` stage.

If this job fails, you can clean up the testnet using another stage/job that always runs on failure.
You may even want to keep the testnet around so that you can investigate the cause of the failed
Terraform run. You need to give the caller of the action the opportunity to do that, without
destroying the network for them. Some notes were added to the README for this.