### PR TITLE
feat: pass value for new client node arg

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,9 @@ runs:
           $WORKING_DIR/sn_testnet_tool/build.sh $WORKING_DIR/id_rsa $repo_owner $commit_hash
           NODE_PATH=$WORKING_DIR/sn_node
         fi
-        $WORKING_DIR/sn_testnet_tool/up.sh \
-          $WORKING_DIR/id_rsa "$NODE_COUNT" "$NODE_PATH" "$NODE_VERSION" "-auto-approve"
+        # The 0 value is to disable the client node, which doesn't apply in this context.
+        ./up.sh \
+          $WORKING_DIR/id_rsa "$NODE_COUNT" "$NODE_PATH" "$NODE_VERSION" "0" "-auto-approve"
     - uses: actions/upload-artifact@v2
       with:
         name: node_connection_info.config


### PR DESCRIPTION
The `up.sh` script now requires a value to be passed for this variable. We don't need the client node when running on GHA, so we can just set the value to 0.