### PR TITLE
feat: add new inputs for custom node binary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,16 +70,9 @@ runs:
         sudo apt-get update -y
         sudo apt-get install -y bsdmainutils curl jq less unzip
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
+        unzip awscliv2.zip >/dev/null 2>&1  # Suppress output: it generates lots of noise in the logs.
         sudo ./aws/install --update
         rm -rf aws awscliv2.zip
-        TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | \
-          jq -r .current_version)
-        curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
-          -o terraform.zip
-        unzip terraform.zip
-        mv terraform /usr/local/bin
-        rm terraform.zip
 
         pip install --user ansible boto3
 
@@ -99,15 +92,15 @@ runs:
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         CUSTOM_BIN_ORG_NAME: ${{ inputs.custom-node-bin-org-name }}
         CUSTOM_BIN_BRANCH_NAME: ${{ inputs.custom-node-bin-branch-name }}
-        SSH_KEY_NAME: id_rsa
         NODE_COUNT: ${{ inputs.node-count }}
         NODE_INSTANCE_COUNT: ${{ inputs.node-instance-count }}
         PROVIDER: ${{ inputs.provider }}
+        SN_TESTNET_DEV_SUBNET_ID: ${{ inputs.subnet-id }}
+        SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
+        SSH_KEY_NAME: id_rsa
         TESTNET_NAME: ${{ inputs.testnet-name }}
         TESTNET_TOOL_BRANCH: ${{ inputs.testnet-tool-repo-branch }}
         TESTNET_TOOL_USER: ${{ inputs.testnet-tool-repo-user }}
-        SN_TESTNET_DEV_SUBNET_ID: ${{ inputs.subnet-id }}
-        SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
         TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
       shell: bash
       run: |
@@ -144,7 +137,7 @@ runs:
         echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> .env
 
         use_custom_bin="false"
-        if [[ ! -z "${{ inputs.custom-node-bin-org }}" ]]; then
+        if [[ ! -z "${{ inputs.custom-node-bin-org-name }}" ]]; then
           use_custom_bin="true"
         fi
         just init "$TESTNET_NAME" "$PROVIDER"
@@ -164,15 +157,15 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
-        SSH_KEY_NAME: id_rsa
         NODE_COUNT: ${{ inputs.node-count }}
         PROVIDER: ${{ inputs.provider }}
+        SN_TESTNET_DEV_SUBNET_ID: ${{ inputs.subnet-id }}
+        SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
+        SSH_KEY_NAME: id_rsa
+        TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
         TESTNET_NAME: ${{ inputs.testnet-name }}
         TESTNET_TOOL_BRANCH: ${{ inputs.testnet-tool-repo-branch }}
         TESTNET_TOOL_USER: ${{ inputs.testnet-tool-repo-user }}
-        SN_TESTNET_DEV_SUBNET_ID: ${{ inputs.subnet-id }}
-        SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
-        TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
       shell: bash
       run: |
         set -e

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: "AWS access key"
   aws-region:
     description: "AWS region"
+  custom-node-bin-org-name:
+    description: >
+      If using a custom node binary, set this to the name of the org or username of the repository.
+      The repository will be cloned and the binary will be built.
+  custom-node-bin-branch-name:
+    description: >
+      If using a custom node binary, set this to the branch on the repository you want to use.
+      The repository will be cloned and the binary will be built using this branch.
   do-token:
     description: "Digital Ocean Authorization token"
   name:
@@ -89,6 +97,8 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        CUSTOM_BIN_ORG_NAME: ${{ inputs.custom-node-bin-org-name }}
+        CUSTOM_BIN_BRANCH_NAME: ${{ inputs.custom-node-bin-branch-name }}
         SSH_KEY_NAME: id_rsa
         NODE_COUNT: ${{ inputs.node-count }}
         NODE_INSTANCE_COUNT: ${{ inputs.node-instance-count }}
@@ -133,8 +143,19 @@ runs:
         echo "SN_TESTNET_DEV_SECURITY_GROUP_ID=${{ env.SN_TESTNET_DEV_SECURITY_GROUP_ID }}" >> .env
         echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> .env
 
+        use_custom_bin="false"
+        if [[ ! -z "${{ inputs.custom-node-bin-org }}" ]]; then
+          use_custom_bin="true"
+        fi
         just init "$TESTNET_NAME" "$PROVIDER"
-        just testnet "$TESTNET_NAME" "$PROVIDER" $NODE_COUNT
+        just testnet \
+          "$TESTNET_NAME" \
+          "$PROVIDER" \
+          $NODE_COUNT \
+          $NODE_INSTANCE_COUNT \
+          "$use_custom_bin" \
+          "$CUSTOM_BIN_ORG_NAME" \
+          "$CUSTOM_BIN_BRANCH_NAME" \
 
     - name: Destroy testnet on Digital Ocean or AWS
       if: inputs.action == 'destroy'

--- a/action.yml
+++ b/action.yml
@@ -1,51 +1,52 @@
-name: "SAFE Network Tesnet Workflow Action"
-description: "GitHub action to deploy a testnet using Digital Ocean droplets"
+name: "SAFE Network Testnet Workflow Action"
+description: "GitHub action to use the sn_testnet_tool repository to deploy a testnet"
 inputs:
   action:
-    description: "Task to be carried out. Accepts 'create' or 'destroy'"
+    description: "Task to be carried out. Accepts 'create' or 'destroy'."
     default: "create"
+  ansible-vault-password:
+    description: Password for Ansible vault.
+    required: true
   aws-access-key-id:
-    description: "AWS Access Key ID"
-    required: true
+    description: "AWS access key ID"
   aws-access-key-secret:
-    description: "AWS Access Key"
-    required: true
-  aws-default-region:
-    description: "AWS Default region"
+    description: "AWS access key"
+  aws-region:
+    description: "AWS region"
   do-token:
     description: "Digital Ocean Authorization token"
-    required: true
   name:
     description: "The name of the testnet"
     required: true
   node-count:
-    description: "Number of nodes to be deployed"
+    description: "Number of node VMs to be deployed"
+    required: true
+  node-instance-count:
+    description: "Number of nodes service instances to be started"
+    required: true
   provider:
     description: "The cloud provider. Valid values are 'aws' or 'digital-ocean'."
     required: true
   ssh-secret-key:
     description: "SSH key used to run the nodes on the Digital Ocean droplets"
     required: true
-  ansible-vault-password:
-    description: Password for Ansible vault.
-    required: true
+  subnet-id:
+    description: If running on AWS, this is the subnet of the VPC on which the VMs will be created.
+  security-group-id:
+    description: If running on AWS, this is the ID of the security groups the VMs will use.
   testnet-name:
-    description: >
-      The name of the testnet.
+    description: The name of the testnet.
+    required: true
   testnet-tool-repo-branch:
     description: >
       The branch for the testnet tool repository. This is to enable using forks to test changes to
       the testnet tool. Will default to the `digital-ocean-refactor` branch.
+    default: "main"
   testnet-tool-repo-user:
     description: >
       The user or organisation for the testnet tool repository. This is to enable using forks to
       test changes to the testnet tool. Will default to the `jacderida`.
-  subnet-id:
-    description: >
-      The testnet dev subnet id for AWS.
-  security-group-id:
-    description: >
-      The testnet dev security group id for AWS.
+    default: "maidsafe"
 
 runs:
   using: "composite"
@@ -87,9 +88,10 @@ runs:
         DO_PAT: ${{ inputs.do-token }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
-        AWS_DEFAULT_REGION: ${{ inputs.aws-default-region }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         SSH_KEY_NAME: id_rsa
         NODE_COUNT: ${{ inputs.node-count }}
+        NODE_INSTANCE_COUNT: ${{ inputs.node-instance-count }}
         PROVIDER: ${{ inputs.provider }}
         TESTNET_NAME: ${{ inputs.testnet-name }}
         TESTNET_TOOL_BRANCH: ${{ inputs.testnet-tool-repo-branch }}
@@ -140,7 +142,7 @@ runs:
         DO_PAT: ${{ inputs.do-token }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
-        AWS_DEFAULT_REGION: ${{ inputs.aws-default-region }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
         SSH_KEY_NAME: id_rsa
         NODE_COUNT: ${{ inputs.node-count }}
         PROVIDER: ${{ inputs.provider }}

--- a/action.yml
+++ b/action.yml
@@ -28,16 +28,13 @@ inputs:
     required: true
   node-count:
     description: "Number of node VMs to be deployed"
-    required: true
   node-instance-count:
     description: "Number of nodes service instances to be started"
-    required: true
   provider:
     description: "The cloud provider. Valid values are 'aws' or 'digital-ocean'."
     required: true
   ssh-secret-key:
     description: "SSH key used to run the nodes on the Digital Ocean droplets"
-    required: true
   subnet-id:
     description: If running on AWS, this is the subnet of the VPC on which the VMs will be created.
   security-group-id:
@@ -83,7 +80,7 @@ runs:
         sudo mv just/just /usr/local/bin
         rm -rf just
 
-    - name: Build node and run testnet on Digital Ocean or AWS
+    - name: Create testnet
       if: inputs.action == 'create'
       env:
         DO_PAT: ${{ inputs.do-token }}
@@ -150,18 +147,14 @@ runs:
           "$CUSTOM_BIN_ORG_NAME" \
           "$CUSTOM_BIN_BRANCH_NAME" \
 
-    - name: Destroy testnet on Digital Ocean or AWS
+    - name: Destroy testnet
       if: inputs.action == 'destroy'
       env:
-        DO_PAT: ${{ inputs.do-token }}
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-access-key-secret }}
         AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
-        NODE_COUNT: ${{ inputs.node-count }}
+        DO_PAT: ${{ inputs.do-token }}
         PROVIDER: ${{ inputs.provider }}
-        SN_TESTNET_DEV_SUBNET_ID: ${{ inputs.subnet-id }}
-        SN_TESTNET_DEV_SECURITY_GROUP_ID: ${{ inputs.security-group-id }}
-        SSH_KEY_NAME: id_rsa
         TERRAFORM_STATE_BUCKET_NAME: maidsafe-org-infra-tfstate
         TESTNET_NAME: ${{ inputs.testnet-name }}
         TESTNET_TOOL_BRANCH: ${{ inputs.testnet-tool-repo-branch }}
@@ -169,19 +162,10 @@ runs:
       shell: bash
       run: |
         set -e
-        mkdir ~/.ssh
-        echo "${{ inputs.ssh-secret-key }}" >> ~/.ssh/id_rsa
-        chmod 0400 ~/.ssh/id_rsa
-        ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
-
-        mkdir ~/.ansible
-        echo "${{ inputs.ansible-vault-password }}" >> ~/.ansible/vault-password
 
         git clone --quiet --single-branch --depth 1 \
           --branch $TESTNET_TOOL_BRANCH https://github.com/$TESTNET_TOOL_USER/sn_testnet_tool
-
         cd sn_testnet_tool
-
         export PATH=$PATH:/home/runner/.local/bin
         echo "DIGITALOCEAN_TOKEN=${{ env.DO_PAT }}" >> .env
         echo "DO_API_TOKEN=${{ env.DO_PAT }}" >> .env
@@ -189,15 +173,6 @@ runs:
         echo "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" >> .env
         echo "AWS_DEFAULT_REGION=${{ env.AWS_DEFAULT_REGION }}" >> .env
         echo "DO_PAT=${{ env.DO_PAT }}" >> .env
-        echo "SSH_KEY_NAME=${{ env.SSH_KEY_NAME }}" >> .env
-        echo "NODE_COUNT=${{ env.NODE_COUNT }}" >> .env
-        echo "PATH=$PATH:/home/runner/.local/bin" >> .env
-        echo "PROVIDER=${{ env.PROVIDER }}" >> .env
-        echo "TESTNET_NAME=${{ env.TESTNET_NAME }}" >> .env
-        echo "TESTNET_TOOL_BRANCH=${{ env.TESTNET_TOOL_BRANCH }}" >> .env
-        echo "TESTNET_TOOL_USER=${{ env.TESTNET_TOOL_USER }}" >> .env
-        echo "SN_TESTNET_DEV_SUBNET_ID=${{ env.SN_TESTNET_DEV_SUBNET_ID}} " >> .env
-        echo "SN_TESTNET_DEV_SECURITY_GROUP_ID=${{ env.SN_TESTNET_DEV_SECURITY_GROUP_ID }}" >> .env
         echo "TERRAFORM_STATE_BUCKET_NAME=${{ env.TERRAFORM_STATE_BUCKET_NAME }}" >> .env
 
         just init "$TESTNET_NAME" "$PROVIDER"


### PR DESCRIPTION
- 99ee6ac **chore: tidy up action input parameters**

  Tidy names, descriptions, default values and whether the parameters are required.

  Also put the input parameters back into alphabetical order.

- 2cc1599 **feat: add new inputs for custom node binary**

  The testnet tool has been extended to accommodate being able to build a custom node branch. We now
  provide additional inputs on this action so we can specify those.

- 36ee063 **chore: setup enhancements**

  The archive for the AWS CLI has thousands of files in it, so the output of the unzip command is
  suppressed because it makes it harder to read the logs.

  We also don't actually need to install Terraform ourselves since the `setup_terraform` action is
  doing that.

- 5543e39 **chore: tidy use of inputs required for destroy**

  When destroying a testnet, you don't need to provide as much information as is necessary when
  creating one. Any information which was not required is removed.